### PR TITLE
[xbmcZ] Adding to Frodo StartAndroidActivity to allow starting Android a...

### DIFF
--- a/xbmc/ApplicationMessenger.cpp
+++ b/xbmc/ApplicationMessenger.cpp
@@ -65,6 +65,7 @@
 #include "windows/GUIWindowLoginScreen.h"
 
 #include "utils/GlobalsHandling.h"
+#include "xbmc/android/activity/XBMCApp.h"
 
 using namespace PVR;
 using namespace std;
@@ -805,6 +806,18 @@ void CApplicationMessenger::ProcessMessage(ThreadMessage *pMsg)
       CGUIWindowLoginScreen::LoadProfile(pMsg->dwParam1);
       break;
     }
+    case TMSG_START_ANDROID_ACTIVITY:
+    {
+      if (pMsg->params.size())
+    {
+      CXBMCApp::StartActivity(pMsg->params[0]); // JoKeRzBoX: chnaged from below (from Gothan) to just one parameter to match Frodo's implementation
+      //XBMCApp::StartActivity(pMsg->params[0],
+      //pMsg->params.size() > 1 ? pMsg->params[1] : "",
+      //pMsg->params.size() > 2 ? pMsg->params[2] : "",
+      //pMsg->params.size() > 3 ? pMsg->params[3] : "");
+    }
+      break;
+    } 
   }
 }
 
@@ -1290,3 +1303,11 @@ void CApplicationMessenger::LoadProfile(unsigned int idx)
   tMsg.dwParam1 = idx;
   SendMessage(tMsg, false);
 }
+
+void CApplicationMessenger::StartAndroidActivity(const vector<CStdString> &params)
+ {
+ ThreadMessage tMsg = {TMSG_START_ANDROID_ACTIVITY};
+ tMsg.params = params;
+ SendMessage(tMsg, false);
+ }
+

--- a/xbmc/ApplicationMessenger.cpp
+++ b/xbmc/ApplicationMessenger.cpp
@@ -65,7 +65,9 @@
 #include "windows/GUIWindowLoginScreen.h"
 
 #include "utils/GlobalsHandling.h"
-#include "xbmc/android/activity/XBMCApp.h"
+#if defined(TARGET_ANDROID)
+  #include "xbmc/android/activity/XBMCApp.h"
+#endif
 
 using namespace PVR;
 using namespace std;
@@ -808,14 +810,16 @@ void CApplicationMessenger::ProcessMessage(ThreadMessage *pMsg)
     }
     case TMSG_START_ANDROID_ACTIVITY:
     {
+#if defined(TARGET_ANDROID)
       if (pMsg->params.size())
     {
-      CXBMCApp::StartActivity(pMsg->params[0]); // JoKeRzBoX: chnaged from below (from Gothan) to just one parameter to match Frodo's implementation
+      CXBMCApp::StartActivity(pMsg->params[0]); // JoKeRzBoX: changed from below (from Gotham) to just one parameter to match Frodo's implementation
       //XBMCApp::StartActivity(pMsg->params[0],
       //pMsg->params.size() > 1 ? pMsg->params[1] : "",
       //pMsg->params.size() > 2 ? pMsg->params[2] : "",
       //pMsg->params.size() > 3 ? pMsg->params[3] : "");
     }
+#endif
       break;
     } 
   }

--- a/xbmc/ApplicationMessenger.h
+++ b/xbmc/ApplicationMessenger.h
@@ -101,6 +101,7 @@ namespace MUSIC_INFO
 #define TMSG_GUI_INFOBOOL             609
 #define TMSG_GUI_ADDON_DIALOG         610
 #define TMSG_GUI_MESSAGE              611
+#define TMSG_START_ANDROID_ACTIVITY   612
 
 #define TMSG_CALLBACK             800
 
@@ -241,7 +242,7 @@ public:
   
   bool SetupDisplay();
   bool DestroyDisplay();
-
+  void StartAndroidActivity(const std::vector<CStdString> &params);
   virtual ~CApplicationMessenger();
 private:
   // private construction, and no assignements; use the provided singleton methods

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -216,6 +216,7 @@ const BUILT_IN commands[] = {
   { "ToggleDebug",                false,  "Enables/disables debug mode" },
   { "StartPVRManager",            false,  "(Re)Starts the PVR manager" },
   { "StopPVRManager",             false,  "Stops the PVR manager" },
+  { "StartAndroidActivity",       true,   "Launch an Android native app with the given package name.  Optional parms (in order): intent, dataType, dataURI." },
 };
 
 bool CBuiltins::HasCommand(const CStdString& execString)
@@ -1638,6 +1639,10 @@ int CBuiltins::Execute(const CStdString& execString)
   else if (execute.Equals("stoppvrmanager"))
   {
     g_application.StopPVRManager();
+  }
+  else if (execute.Equals("StartAndroidActivity") && params.size() > 0)
+  {
+    CApplicationMessenger::Get().StartAndroidActivity(params);
   }
   else
     return -1;

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -216,7 +216,9 @@ const BUILT_IN commands[] = {
   { "ToggleDebug",                false,  "Enables/disables debug mode" },
   { "StartPVRManager",            false,  "(Re)Starts the PVR manager" },
   { "StopPVRManager",             false,  "Stops the PVR manager" },
+#if defined(TARGET_ANDROID)
   { "StartAndroidActivity",       true,   "Launch an Android native app with the given package name.  Optional parms (in order): intent, dataType, dataURI." },
+#endif
 };
 
 bool CBuiltins::HasCommand(const CStdString& execString)


### PR DESCRIPTION
...pps

similarly to what already exists in the Gotham code base.

Sample call from a plugin (default.py file):
       xbmc.executebuiltin('XBMC.StartAndroidActivity("com.androidemu.gens")')

I compiled spmc with these changes and tested the APK and it does work. It is based on what was suggested in the forum by elmerohueso (http://ouyaforum.com/showthread.php?8220-SPMC-Koying&p=99046&viewfull=1#post99046), with some additional required changes to make it work.
