### PR TITLE
ADD: Define AndroidApps as a program section

### DIFF
--- a/xbmc/programs/GUIWindowPrograms.cpp
+++ b/xbmc/programs/GUIWindowPrograms.cpp
@@ -194,6 +194,8 @@ CStdString CGUIWindowPrograms::GetStartFolder(const CStdString &dir)
 {
   if (dir.Equals("Plugins") || dir.Equals("Addons"))
     return "addons://sources/executable/";
+  else if (dir.Equals("AndroidApps"))
+    return "androidapp://sources/apps/";
     
   SetupShares();
   VECSOURCES shares;


### PR DESCRIPTION
Allows for ActivateWindow(Programs,AndroidApps) as shorthand for
ActivateWindow(Programs,androidapp://sources/apps/), to open
the Android Apps list directly.
