### PR TITLE
Update ExternalPlayer.cpp

### DIFF
--- a/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
+++ b/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
@@ -493,14 +493,14 @@ BOOL CExternalPlayer::ExecuteAppAndroid(const char* strSwitches,const char* strP
 {
   CLog::Log(LOGNOTICE, "%s: %s", __FUNCTION__, strSwitches);
 
-  int ret = CXBMCApp::StartActivity(strSwitches, "android.intent.action.VIEW", "video/*", strPath);
+  bool ret = CXBMCApp::StartActivity(strSwitches, "android.intent.action.VIEW", "video/*", strPath);
 
-  if (ret != 0)
+  if (!ret)
   {
-    CLog::Log(LOGNOTICE, "%s: Failure: %d", __FUNCTION__, ret);
+    CLog::Log(LOGNOTICE, "%s: Failure", __FUNCTION__);
   }
 
-  return ret == 0;
+  return ret;
 }
 #endif
 


### PR DESCRIPTION
FIX: [droid] return type mismatch when launching ext app 
from: https://github.com/xbmc/xbmc/commit/174f4a357cbdd04f7c7c78297cc6203213c27b04
