### PR TITLE
FIX: GLES font corruption inevitable after few days runtime

### DIFF
--- a/xbmc/guilib/GUIFontTTFGL.cpp
+++ b/xbmc/guilib/GUIFontTTFGL.cpp
@@ -232,7 +232,7 @@ void CGUIFontTTFGL::LastEnd()
       glUniformMatrix4fv(modelLoc, 1, GL_FALSE, glMatrixModview.Get());
 
       // Bind the buffer to the OpenGL context's GL_ARRAY_BUFFER binding point
-      glBindBuffer(GL_ARRAY_BUFFER, (GLuint) ((long)(m_vertexTrans[i].vertexBuffer->bufferHandle) & 0xffff));
+      glBindBuffer(GL_ARRAY_BUFFER, (GLuint) m_vertexTrans[i].vertexBuffer->bufferHandle);
 
       // Do the actual drawing operation, split into groups of characters no
       // larger than the pre-determined size of the element array


### PR DESCRIPTION
This fixes #327 by reverting commit 3e897c524e84c33c09a6d93f1fc5cf03490e9aa3, described as "FIX: [64bits] GLuint <-> void\* conversion in fontTTFGL".

The old commit has some problems:
- Use of a 16-bit mask is broken: actual **bufferHandle** values eventually exceed this limit and cause font rendering corruption.  The GL spec explicitly says type _GLuint_ is 32-bit, but in any case the point of using these abstract library types is to avoid assuming these details.
- Using a signed explicit cast just invites future sign-extension problems.

Which brings me to my main concern. What problem was the original commit trying to fix?  Was it just a compiler warning?  Could you elaborate, @koying ?  It looks like it should work on a 64-bit platform, but I wasn't able to do an arm64 build successfully to confirm.  Could you share your NDK/SDK details, and especially the "configure" line you use for building arm64?

Looking around the code I can see how things could get a little messy if you're trying to keep the bufferHandle type consistent across platforms (e.g. the DX implementation, using "reinterpret_cast").
