### PR TITLE
[GUIFont] Use explicit GLuint bufferhandle type and initializer

### DIFF
--- a/xbmc/guilib/GUIFontCache.h
+++ b/xbmc/guilib/GUIFontCache.h
@@ -125,7 +125,7 @@ public:
   CGUIFontCache(CGUIFontTTFBase &font);
 
   ~CGUIFontCache();
-
+ 
   Value &Lookup(Position &pos,
                 const vecColors &colors, const vecText &text,
                 uint32_t alignment, float maxPixelWidth,
@@ -178,7 +178,7 @@ struct CVertexBuffer
 #endif
   BufferHandleType bufferHandle; // this is really a GLuint
   size_t size;
-  CVertexBuffer() : bufferHandle(0), size(0), m_font(NULL) {}
+  CVertexBuffer() : bufferHandle(NULL), size(0), m_font(NULL) {}
   CVertexBuffer(BufferHandleType bufferHandle, size_t size, const CGUIFontTTFBase *font) : bufferHandle(bufferHandle), size(size), m_font(font) {}
   CVertexBuffer(const CVertexBuffer &other) : bufferHandle(other.bufferHandle), size(other.size), m_font(other.m_font)
   {

--- a/xbmc/guilib/GUIFontCache.h
+++ b/xbmc/guilib/GUIFontCache.h
@@ -38,7 +38,7 @@
 #include <cassert>
 
 #include "TransformMatrix.h"
-#include "system.h"
+#include "system_gl.h"
 
 #define FONT_CACHE_TIME_LIMIT (1000)
 #define FONT_CACHE_DIST_LIMIT (0.01f)
@@ -125,7 +125,7 @@ public:
   CGUIFontCache(CGUIFontTTFBase &font);
 
   ~CGUIFontCache();
- 
+
   Value &Lookup(Position &pos,
                 const vecColors &colors, const vecText &text,
                 uint32_t alignment, float maxPixelWidth,
@@ -172,13 +172,13 @@ struct CGUIFontCacheDynamicPosition
 struct CVertexBuffer
 {
 #if defined(HAS_GL) || defined(HAS_GLES)
-  typedef unsigned int BufferHandleType;
+  typedef GLuint BufferHandleType;
 #define  BUFFER_HANDLE_INIT 0
 #elif defined(HAS_DX)
   typedef void* BufferHandleType;
 #define BUFFER_HANDLE_INIT nullptr
 #endif
-  BufferHandleType bufferHandle; // this is really a GLuint
+  BufferHandleType bufferHandle;
   size_t size;
   CVertexBuffer() : bufferHandle(BUFFER_HANDLE_INIT), size(0), m_font(NULL) {}
   CVertexBuffer(BufferHandleType bufferHandle, size_t size, const CGUIFontTTFBase *font) : bufferHandle(bufferHandle), size(size), m_font(font) {}
@@ -187,14 +187,14 @@ struct CVertexBuffer
     /* In practice, the copy constructor is only called before a vertex buffer
      * has been attached. If this should ever change, we'll need another support
      * function in GUIFontTTFGL/DX to duplicate a buffer, given its handle. */
-    assert(other.bufferHandle == 0);
+    assert(other.bufferHandle == BUFFER_HANDLE_INIT);
   }
   CVertexBuffer &operator=(CVertexBuffer &other)
   {
     /* This is used with move-assignment semantics for initialising the object in the font cache */
-    assert(bufferHandle == 0);
+    assert(bufferHandle == BUFFER_HANDLE_INIT);
     bufferHandle = other.bufferHandle;
-    other.bufferHandle = 0;
+    other.bufferHandle = BUFFER_HANDLE_INIT;
     size = other.size;
     m_font = other.m_font;
     return *this;

--- a/xbmc/guilib/GUIFontCache.h
+++ b/xbmc/guilib/GUIFontCache.h
@@ -173,12 +173,14 @@ struct CVertexBuffer
 {
 #if defined(HAS_GL) || defined(HAS_GLES)
   typedef unsigned int BufferHandleType;
+#define  BUFFER_HANDLE_INIT 0
 #elif defined(HAS_DX)
   typedef void* BufferHandleType;
+#define BUFFER_HANDLE_INIT nullptr
 #endif
   BufferHandleType bufferHandle; // this is really a GLuint
   size_t size;
-  CVertexBuffer() : bufferHandle(NULL), size(0), m_font(NULL) {}
+  CVertexBuffer() : bufferHandle(BUFFER_HANDLE_INIT), size(0), m_font(NULL) {}
   CVertexBuffer(BufferHandleType bufferHandle, size_t size, const CGUIFontTTFBase *font) : bufferHandle(bufferHandle), size(size), m_font(font) {}
   CVertexBuffer(const CVertexBuffer &other) : bufferHandle(other.bufferHandle), size(other.size), m_font(other.m_font)
   {

--- a/xbmc/guilib/GUIFontTTFDX.cpp
+++ b/xbmc/guilib/GUIFontTTFDX.cpp
@@ -206,7 +206,7 @@ void CGUIFontTTFDX::DestroyVertexBuffer(CVertexBuffer &buffer) const
     CD3DBuffer* vbuffer = reinterpret_cast<CD3DBuffer*>(buffer.bufferHandle);
     ClearReference((CGUIFontTTFDX*)this, vbuffer);
     SAFE_DELETE(vbuffer);
-    buffer.bufferHandle = 0;
+    buffer.bufferHandle = nullptr;
   }
 }
 

--- a/xbmc/guilib/GUIFontTTFGL.cpp
+++ b/xbmc/guilib/GUIFontTTFGL.cpp
@@ -293,7 +293,7 @@ void CGUIFontTTFGL::DestroyVertexBuffer(CVertexBuffer &buffer) const
   if (buffer.bufferHandle != 0)
   {
     // Release the buffer name for reuse
-    glDeleteBuffers(1, (GLuint *) &buffer.bufferHandle);
+    glDeleteBuffers(1, &buffer.bufferHandle);
     buffer.bufferHandle = 0;
   }
 }


### PR DESCRIPTION
These 3 commits, 2 from upstream Kodi, help avoid potential pointer/integer and integer/integer conversion problems. I applied them for safety while investigating a current GLES memory corruption issue with SPMC 16.4.81.
