### PR TITLE
[FIX] Ignore MEDIA_BUTTON intent received while not playing

### DIFF
--- a/xbmc/android/activity/XBMCApp.cpp
+++ b/xbmc/android/activity/XBMCApp.cpp
@@ -954,6 +954,11 @@ void CXBMCApp::onReceive(CJNIIntent intent)
   }
   else if (action == "android.intent.action.MEDIA_BUTTON")
   {
+    if (!g_application.m_pPlayer->IsPlaying())
+    {
+      CLog::Log(LOGINFO, "Ignore MEDIA_BUTTON intent: no media playing");
+      return;
+    }
     CJNIKeyEvent keyevt = (CJNIKeyEvent)intent.getParcelableExtra(CJNIIntent::EXTRA_KEY_EVENT);
 
     int keycode = keyevt.getKeyCode();


### PR DESCRIPTION
This fixes the problem of having media keys firing twice, especially on FireTV and while mapping FF/RW to PGDN/PGUP keys for list scrolling, as reported by many users:
- http://forum.kodi.tv/showthread.php?tid=258104&page=2
- http://trac.kodi.tv/ticket/16606
- http://forum.kodi.tv/showthread.php?tid=249193&page=3

The problem seems to be a common (but incorrect) assumption that after calling `unregisterMediaButtonEventReceiver`, your app wont receive ACTION_MEDIA_BUTTON intents.  But this isn't guaranteed, e.g. looking at [Allowing applications to play nice(r) with each other: Handling remote control buttons](https://android-developers.blogspot.ca/2010/06/allowing-applications-to-play-nicer.html):

> Once the registration call is placed, the designated component will exclusively receive the ACTION_MEDIA_BUTTON intent ...
> The system handles the media button registration requests in a “last one wins” manner.
> If we had previously registered our receiver, registering it again will push it up the stack, and doesn’t cause any duplicate registration.
> After “unregistering”, the previous component that requested to receive the media button intents will once again receive them. 

But if there is no previous registered component after unregistering and "popping the stack", then it's reasonable that all components that registered ACTION_MEDIA_BUTTON in their manifest could receive the intents. I believe this is what's happening with the SPMC/Kodi bug above.
