### PR TITLE
Refresh rate adjustment and other fixes

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4627,8 +4627,7 @@ void CApplication::ProcessSlow()
   // check for any idle curl connections
   g_curlInterface.CheckIdle();
 
-  if (!m_pPlayer->IsPlayingVideo())
-    g_largeTextureManager.CleanupUnusedImages();
+  g_largeTextureManager.CleanupUnusedImages();
 
   g_TextureManager.FreeUnusedTextures(5000);
 

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.h
@@ -22,6 +22,7 @@
 #include "cores/AudioEngine/Utils/AEAudioFormat.h"
 #include "cores/AudioEngine/Interfaces/AE.h"
 #include "cores/AudioEngine/DSPAddons/ActiveAEDSP.h"
+#include <atomic>
 #include <deque>
 
 extern "C" {
@@ -73,7 +74,7 @@ public:
   int64_t timestamp;
   int clockId;
   int pkt_start_offset;
-  int refCount;
+  std::atomic<int> refCount;
 };
 
 class CActiveAEBufferPool

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
@@ -361,6 +361,7 @@ void CActiveAEStream::Drain(bool wait)
         msgData.stream = this;
         msgData.buffer = *((CSampleBuffer**)msg->data);
         msg->Reply(CActiveAEDataProtocol::STREAMSAMPLE, &msgData, sizeof(MsgStreamSample));
+        msg->Release();
         DecFreeBuffers();
         continue;
       }

--- a/xbmc/guilib/TextureManager.cpp
+++ b/xbmc/guilib/TextureManager.cpp
@@ -253,6 +253,8 @@ bool CGUITextureManager::CanLoad(const std::string &texturePath)
 
 bool CGUITextureManager::HasTexture(const std::string &textureName, std::string *path, int *bundle, int *size)
 {
+  CSingleLock lock(m_section);
+
   // default values
   if (bundle) *bundle = -1;
   if (size) *size = 0;

--- a/xbmc/windowing/egl/WinSystemEGL.cpp
+++ b/xbmc/windowing/egl/WinSystemEGL.cpp
@@ -57,6 +57,7 @@ CWinSystemEGL::CWinSystemEGL() : CWinSystemBase()
   m_surface           = EGL_NO_SURFACE;
   m_context           = EGL_NO_CONTEXT;
   m_config            = NULL;
+  m_stereo_mode       = RENDER_STEREO_MODE_OFF;
 
   m_egl               = NULL;
   m_iVSyncMode        = 0;
@@ -278,6 +279,7 @@ bool CWinSystemEGL::CreateNewWindow(const std::string& name, bool fullScreen, RE
 {
   RESOLUTION_INFO current_resolution;
   current_resolution.iWidth = current_resolution.iHeight = 0;
+  RENDER_STEREO_MODE stereo_mode = g_graphicsContext.GetStereoMode();
 
   m_nWidth        = res.iWidth;
   m_nHeight       = res.iHeight;
@@ -289,12 +291,14 @@ bool CWinSystemEGL::CreateNewWindow(const std::string& name, bool fullScreen, RE
     current_resolution.iWidth == res.iWidth && current_resolution.iHeight == res.iHeight &&
     current_resolution.iScreenWidth == res.iScreenWidth && current_resolution.iScreenHeight == res.iScreenHeight &&
     m_bFullScreen == fullScreen && current_resolution.fRefreshRate == res.fRefreshRate &&
-    (current_resolution.dwFlags & D3DPRESENTFLAG_MODEMASK) == (res.dwFlags & D3DPRESENTFLAG_MODEMASK))
+    (current_resolution.dwFlags & D3DPRESENTFLAG_MODEMASK) == (res.dwFlags & D3DPRESENTFLAG_MODEMASK) &&
+    m_stereo_mode == stereo_mode)
   {
     CLog::Log(LOGDEBUG, "CWinSystemEGL::CreateNewWindow: No need to create a new window");
     return true;
   }
 
+  m_stereo_mode = stereo_mode;
   m_bFullScreen   = fullScreen;
   // Destroy any existing window
   if (m_surface != EGL_NO_SURFACE)

--- a/xbmc/windowing/egl/WinSystemEGL.cpp
+++ b/xbmc/windowing/egl/WinSystemEGL.cpp
@@ -292,7 +292,7 @@ bool CWinSystemEGL::CreateNewWindow(const std::string& name, bool fullScreen, RE
     (current_resolution.dwFlags & D3DPRESENTFLAG_MODEMASK) == (res.dwFlags & D3DPRESENTFLAG_MODEMASK))
   {
     CLog::Log(LOGDEBUG, "CWinSystemEGL::CreateNewWindow: No need to create a new window");
-//xxx    return true;
+    return true;
   }
 
   m_bFullScreen   = fullScreen;

--- a/xbmc/windowing/egl/WinSystemEGL.cpp
+++ b/xbmc/windowing/egl/WinSystemEGL.cpp
@@ -152,13 +152,26 @@ bool CWinSystemEGL::InitWindowSystem()
 
 bool CWinSystemEGL::CreateWindow(RESOLUTION_INFO &res)
 {
+  RESOLUTION_INFO current_resolution;
+  current_resolution.iWidth = current_resolution.iHeight = 0;
+  RENDER_STEREO_MODE stereo_mode = g_graphicsContext.GetStereoMode();
+
   if (!m_egl)
   {
     CLog::Log(LOGERROR, "CWinSystemEGL::CreateWindow no EGL!");
     return false;
   }
 
-  if(m_egl)
+  if (m_egl->GetNativeResolution(&current_resolution) &&
+    current_resolution.iWidth == res.iWidth && current_resolution.iHeight == res.iHeight &&
+    current_resolution.iScreenWidth == res.iScreenWidth && current_resolution.iScreenHeight == res.iScreenHeight &&
+    current_resolution.fRefreshRate == res.fRefreshRate &&
+    (current_resolution.dwFlags & D3DPRESENTFLAG_MODEMASK) == (res.dwFlags & D3DPRESENTFLAG_MODEMASK) &&
+    m_stereo_mode == stereo_mode)
+  {
+    CLog::Log(LOGDEBUG, "%s: No need to call SetNativeResolution",__FUNCTION__);
+  }
+  else
     m_egl->SetNativeResolution(res);
 
   int quirks;

--- a/xbmc/windowing/egl/WinSystemEGL.h
+++ b/xbmc/windowing/egl/WinSystemEGL.h
@@ -81,6 +81,7 @@ protected:
   EGLSurface            m_surface;
   EGLContext            m_context;
   EGLConfig             m_config;
+  RENDER_STEREO_MODE    m_stereo_mode;
 
   CEGLWrapper           *m_egl;
   std::string           m_extensions;


### PR DESCRIPTION
Some upstream safety/correctness updates I came across and a fix for the broken refresh rate adjustment I ran into on AFTV v1.  These only have some runtime on my AFTV box.

Suggestions, changes, etc. welcome.